### PR TITLE
Introduce basic INI Parsing and configuration and simplification

### DIFF
--- a/cmd/example/config.ini
+++ b/cmd/example/config.ini
@@ -1,15 +1,15 @@
 [blocklist]
-default = true	;; use default blocklist domains if true
+#default = true	;; use default blocklist domains if true
 
-HBLFromFile = false  ;; load list from a file rather than using an INI-key if true
+#HBLFromFile = false  ;; load list from a file rather than using an INI-key if true
 #HBLFileLoc = "/path/to/file"  ;; file location for HTTPSBlockList
-HTTPSBlockList = "google\.com"
+HTTPSBlockList = "google.com"
 
-TBLFromFile = false  ;; load list from a file rather than using an INI-key if true
+#TBLFromFile = false  ;; load list from a file rather than using an INI-key if true
 #TBLFileLoc = "/path/to/file"  ;; file location for TelemetryBlockList
-TelemetryBlockList = "bing\.com"
+TelemetryBlockList = "bing.com"
 
-ELFromFile = false  ;; load list from a file rather than using an INI-key if true
+#ELFromFile = false  ;; load list from a file rather than using an INI-key if true
 #ELFileLoc = "/path/to/file"  ;; file location for ExcludeLog
 ExcludeLog = ""
 

--- a/cmd/example/config.ini
+++ b/cmd/example/config.ini
@@ -3,15 +3,15 @@
 
 #HBLFromFile = false  ;; load list from a file rather than using an INI-key if true
 #HBLFileLoc = "/path/to/file"  ;; file location for HTTPSBlockList
-HTTPSBlockList = "google.com"
+HTTPSBlockList = "appguard\.com\.cn"
 
 #TBLFromFile = false  ;; load list from a file rather than using an INI-key if true
 #TBLFileLoc = "/path/to/file"  ;; file location for TelemetryBlockList
-TelemetryBlockList = "bing.com"
+TelemetryBlockList = "graph\.facebook\.com appsflyer\.com sessions\.bugsnag\.com cloud\.unity3d\.com rayjump\.com duapps\.com spykemedia\.g2afse\.com ldmnq\.com erntech\.net st\.frecorp\.net apitask\.doglobal\.net baidu\.clickurl\.to"
 
 #ELFromFile = false  ;; load list from a file rather than using an INI-key if true
 #ELFileLoc = "/path/to/file"  ;; file location for ExcludeLog
-ExcludeLog = ""
+ExcludeLog = "gf-transit\.sunborngame\.com track-us\.sunborngame\.com dkn3dfwjnmzcj\.cloudfront\.net/image/ImageConfig gf-dc\.sunborngame\.com s3.us-east-2\.amazonaws\.com:443/gf1-file-server/ cs30\.net google gstatic"
 
 [mods]
 ;; possibly used modes here

--- a/cmd/example/config.ini
+++ b/cmd/example/config.ini
@@ -1,0 +1,23 @@
+[blocklist]
+default = true	;; use default blocklist domains if true
+
+HBLFromFile = false  ;; load list from a file rather than using an INI-key if true
+#HBLFileLoc = "/path/to/file"  ;; file location for HTTPSBlockList
+HTTPSBlockList = "google\.com"
+
+TBLFromFile = false  ;; load list from a file rather than using an INI-key if true
+#TBLFileLoc = "/path/to/file"  ;; file location for TelemetryBlockList
+TelemetryBlockList = "bing\.com"
+
+ELFromFile = false  ;; load list from a file rather than using an INI-key if true
+#ELFileLoc = "/path/to/file"  ;; file location for ExcludeLog
+ExcludeLog = ""
+
+[mods]
+;; possibly used modes here
+;; the key for new mods will have to be added to the parser
+;; most likely a struct holding INI-key names and optional config sections used as on/off switches and the mods they bind to
+
+[<mod name>-config]  ;; or separate config file handled by modules
+;; optional mod configuration
+;; option keys will either reside in the same struct used to list mods and their keys or in a separate struct

--- a/cmd/example/hoxy.go
+++ b/cmd/example/hoxy.go
@@ -1,19 +1,34 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+
 	"github.com/kyoukaya/hoxy/proxy"
 	"github.com/kyoukaya/hoxy/proxy/core/userauth"
+	"github.com/kyoukaya/hoxy/utils"
 
 	_ "github.com/kyoukaya/hoxy/mods/constructioninfo"
 	_ "github.com/kyoukaya/hoxy/mods/packetlogger"
 )
 
 func main() {
+	var floc string
+	var help bool
+	flag.StringVar(&floc, "c", "", "ini config file location")
+	flag.BoolVar(&help, "h", false, "Shows the help menu")
+	flag.Parse()
+	if help {
+		fmt.Println("  -h    This Menu\n  -c    INI Config file location")
+	}
+
+	utils.ReadFileIntoList(floc, ' ')
 	filters := proxy.Filters{
 		HTTPSFilter:     proxy.DefaultHTTPSFilter,
 		TelemetryFilter: proxy.DefaultTelemetryFilter,
 		LogFilter:       proxy.DefaultLogFilter,
 	}
+
 	hoxy := proxy.NewHoxy(proxy.GlobalGameBaseURL, userauth.AuthHandler, filters)
 	hoxy.LogGamePackets(true)
 	hoxy.Start()

--- a/cmd/example/hoxy.go
+++ b/cmd/example/hoxy.go
@@ -1,35 +1,12 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-
 	"github.com/kyoukaya/hoxy/proxy"
-	"github.com/kyoukaya/hoxy/proxy/core/userauth"
-	"github.com/kyoukaya/hoxy/utils"
 
 	_ "github.com/kyoukaya/hoxy/mods/constructioninfo"
 	_ "github.com/kyoukaya/hoxy/mods/packetlogger"
 )
 
 func main() {
-	var floc string
-	var help bool
-	flag.StringVar(&floc, "c", "", "ini config file location")
-	flag.BoolVar(&help, "h", false, "Shows the help menu")
-	flag.Parse()
-	if help {
-		fmt.Println("  -h    This Menu\n  -c    INI Config file location")
-	}
-
-	utils.ReadFileIntoList(floc, ' ')
-	filters := proxy.Filters{
-		HTTPSFilter:     proxy.DefaultHTTPSFilter,
-		TelemetryFilter: proxy.DefaultTelemetryFilter,
-		LogFilter:       proxy.DefaultLogFilter,
-	}
-
-	hoxy := proxy.NewHoxy(proxy.GlobalGameBaseURL, userauth.AuthHandler, filters)
-	hoxy.LogGamePackets(true)
-	hoxy.Start()
+	proxy.Start()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,20 @@
 module github.com/kyoukaya/hoxy
 
-go 1.12
+go 1.18
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2
-	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
 	github.com/logrusorgru/aurora v0.0.0-20190803045625-94edacc10f9b
 	github.com/mattn/go-colorable v0.1.2
-	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/sergi/go-diff v1.0.0
+	gopkg.in/ini.v1 v1.67.0
+)
+
+require (
+	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 // indirect
+	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
+	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,7 +26,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/utils/cert.go
+++ b/utils/cert.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/elazarl/goproxy"
@@ -28,11 +28,11 @@ func LoadCA() error {
 	}
 	defer keyFile.Close()
 
-	caCert, err := ioutil.ReadAll(certFile)
+	caCert, err := io.ReadAll(certFile)
 	if err != nil {
 		return err
 	}
-	caKey, err := ioutil.ReadAll(keyFile)
+	caKey, err := io.ReadAll(keyFile)
 	if err != nil {
 		return err
 	}

--- a/utils/fileio.go
+++ b/utils/fileio.go
@@ -1,8 +1,16 @@
+package utils
+
+import (
+	"bufio"
+	"io"
+	"os"
+)
+
 // read a file from specified location
-func readFileIntoList(fileloc string) []string {
+func ReadFileIntoList(fileloc string, delim byte) []string {
 	// open file from string and check for errors
 	fr, err := os.Open(fileloc)
-	utils.Check(err)
+	Check(err)
 
 	// create a new buffered reader
 	bufr := bufio.NewReader(fr)
@@ -12,28 +20,13 @@ func readFileIntoList(fileloc string) []string {
 	// loop counter
 	for {
 		// initialize buffers and read a line from a file in a loop
-		dat, err := bufr.ReadString('\n')
+		dat, err := bufr.ReadString(delim)
 		if err == io.EOF {
 			break
 		}
-		utils.Check(err)
-		list = append(list, string(dat))
-  }
+		Check(err)
+		list = append(list, dat)
+	}
 
-  return list
-}
-
-// read a file from specified location as []byte
-func readFileIntoByte(fileloc string) []byte {
-	// open file from string and check for errors
-	fr, err := os.Open(fileloc)
-	utils.Check(err)
-
-	// create a new buffered reader
-	bufr := bufio.NewReader(fr)
-
-	dat, err := bufr.ReadBytes(0)
-	utils.Check(err)
-
-	return dat
+	return list
 }

--- a/utils/fileio.go
+++ b/utils/fileio.go
@@ -1,0 +1,39 @@
+// read a file from specified location
+func readFileIntoList(fileloc string) []string {
+	// open file from string and check for errors
+	fr, err := os.Open(fileloc)
+	utils.Check(err)
+
+	// create a new buffered reader
+	bufr := bufio.NewReader(fr)
+
+	// create the finished []string
+	var list []string
+	// loop counter
+	for {
+		// initialize buffers and read a line from a file in a loop
+		dat, err := bufr.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		utils.Check(err)
+		list = append(list, string(dat))
+  }
+
+  return list
+}
+
+// read a file from specified location as []byte
+func readFileIntoByte(fileloc string) []byte {
+	// open file from string and check for errors
+	fr, err := os.Open(fileloc)
+	utils.Check(err)
+
+	// create a new buffered reader
+	bufr := bufio.NewReader(fr)
+
+	dat, err := bufr.ReadBytes(0)
+	utils.Check(err)
+
+	return dat
+}

--- a/utils/ini.go
+++ b/utils/ini.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"gopkg.in/ini.v1"
+)
+
+func INIParsefromByte(data []byte, sect string, key string, typ string) any {
+	cfg, err := ini.Load(data)
+
+	if err != nil {
+		panic(err)
+	}
+
+	switch typ {
+	case "string":
+		return cfg.Section(sect).Key(key).String()
+
+	case "bool":
+		ret, err := cfg.Section(sect).Key(key).Bool()
+		if err != nil {
+			panic(err)
+		}
+		return ret
+
+	case "int":
+		ret, err := cfg.Section(sect).Key(key).Int()
+		if err != nil {
+			panic(err)
+		}
+		return ret
+	}
+
+	return nil
+}
+
+func INIParsefromFile(floc string, sect string, key string, typ string) any {
+	cfg, err := ini.Load(floc)
+
+	if err != nil {
+		panic(err)
+	}
+
+	switch typ {
+	case "string":
+		return cfg.Section(sect).Key(key).String()
+
+	case "[]string":
+		return cfg.Section(sect).Key(key).Strings(" ")
+
+	case "bool":
+		ret, err := cfg.Section(sect).Key(key).Bool()
+		if err != nil {
+			panic(err)
+		}
+		return ret
+
+	case "int":
+		ret, err := cfg.Section(sect).Key(key).Int()
+		if err != nil {
+			panic(err)
+		}
+		return ret
+	}
+
+	return nil
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -53,8 +53,12 @@ func ParseFlags() {
 	logVerbose := flag.Bool("hoxy-verbose", false, "log more Hoxy information")
 	addr := flag.String("addr", ":8080", "proxy listen address")
 	https := flag.Bool("https", false, "MITM https connections. Requires loading a CA")
+	floc := flag.String("c", "", "INI Config File location")
+
 	flag.Parse()
+
 	stringFlags["addr"] = *addr
+	stringFlags["c"] = *floc
 	boolFlags["v"] = *verbose
 	boolFlags["hoxy-verbose"] = *logVerbose
 	boolFlags["https"] = *https


### PR DESCRIPTION
Currently only the HTTPSBlockList, TelemetryBlockList and ExcludeLog Keys work. If no config file is specified default options are used. proxy.Start() configures itself fully.